### PR TITLE
Plugin for old releases

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1,5 +1,5 @@
 {
-	"m_title" : "Wiren Board MQTT Integration Old Stretch Releases",
+	"m_title" : "Wiren Board MQTT Integration",
 	"m_descr" : "This version of the plugin can only be run under old stable Wiren Board releases (earlier than wb-2304). Please install latest Wiren Board software to use new version of the plugin (search Wiren Board MQTT Integration in application market to find it). To more information, refer to Wiren Board Wiki (https://wirenboard.com/wiki/Z-Wave). Publishes the status of devices to a Wiren Board MQTT topic and is able to set values based on subscribed topics.",
 
 	"client_id_label": "Client ID",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1,6 +1,8 @@
 {
-	"m_title" : "Wiren Board MQTT Integration",
-	"m_descr" : "Publishes the status of devices to a Wiren Board MQTT topic and is able to set values based on subscribed topics.",
+	"m_title" : "Wiren Board MQTT Integration Old Stretch Releases",
+	"m_descr" : "This version of the plugin can only be run under old stable Wiren Board releases (earlier than wb-2304). Please install latest Wiren Board software to use new version of the plugin (search Wiren Board MQTT Integration in application market to find it). To more information, refer to Wiren Board Wiki (https://wirenboard.com/wiki/Z-Wave). 
+
+	Publishes the status of devices to a Wiren Board MQTT topic and is able to set values based on subscribed topics.",
 
 	"client_id_label": "Client ID",
 	"client_id_randomize_label": "Randomize client ID",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1,6 +1,6 @@
 {
 	"m_title" : "Wiren Board MQTT Integration",
-	"m_descr" : "This version of the plugin can only be run under old stable Wiren Board releases (earlier than wb-2304). Please install latest Wiren Board software to use new version of the plugin (search 'Wiren Board MQTT Integration 2' in application market to find it). To more information, refer to Wiren Board Wiki (https://wirenboard.com/wiki/Z-Wave). Publishes the status of devices to a Wiren Board MQTT topic and is able to set values based on subscribed topics.",
+	"m_descr" : "This version of the plugin can only be run under old stable Wiren Board releases (earlier than wb-2304). Please install latest Wiren Board software to use new version of the plugin (search 'Wiren Board MQTT Integration Native' in application market to find it). For more information, refer to Wiren Board Wiki (https://wirenboard.com/wiki/Z-Wave). Publishes the status of devices to a Wiren Board MQTT topic and is able to set values based on subscribed topics.",
 
 	"client_id_label": "Client ID",
 	"client_id_randomize_label": "Randomize client ID",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1,8 +1,6 @@
 {
 	"m_title" : "Wiren Board MQTT Integration Old Stretch Releases",
-	"m_descr" : "This version of the plugin can only be run under old stable Wiren Board releases (earlier than wb-2304). Please install latest Wiren Board software to use new version of the plugin (search Wiren Board MQTT Integration in application market to find it). To more information, refer to Wiren Board Wiki (https://wirenboard.com/wiki/Z-Wave). 
-
-	Publishes the status of devices to a Wiren Board MQTT topic and is able to set values based on subscribed topics.",
+	"m_descr" : "This version of the plugin can only be run under old stable Wiren Board releases (earlier than wb-2304). Please install latest Wiren Board software to use new version of the plugin (search Wiren Board MQTT Integration in application market to find it). To more information, refer to Wiren Board Wiki (https://wirenboard.com/wiki/Z-Wave). Publishes the status of devices to a Wiren Board MQTT topic and is able to set values based on subscribed topics.",
 
 	"client_id_label": "Client ID",
 	"client_id_randomize_label": "Randomize client ID",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1,6 +1,6 @@
 {
 	"m_title" : "Wiren Board MQTT Integration",
-	"m_descr" : "This version of the plugin can only be run under old stable Wiren Board releases (earlier than wb-2304). Please install latest Wiren Board software to use new version of the plugin (search Wiren Board MQTT Integration in application market to find it). To more information, refer to Wiren Board Wiki (https://wirenboard.com/wiki/Z-Wave). Publishes the status of devices to a Wiren Board MQTT topic and is able to set values based on subscribed topics.",
+	"m_descr" : "This version of the plugin can only be run under old stable Wiren Board releases (earlier than wb-2304). Please install latest Wiren Board software to use new version of the plugin (search 'Wiren Board MQTT Integration 2' in application market to find it). To more information, refer to Wiren Board Wiki (https://wirenboard.com/wiki/Z-Wave). Publishes the status of devices to a Wiren Board MQTT topic and is able to set values based on subscribed topics.",
 
 	"client_id_label": "Client ID",
 	"client_id_randomize_label": "Randomize client ID",

--- a/module.json
+++ b/module.json
@@ -21,7 +21,7 @@
 	"homepage": "https://github.com/wirenboard/wb-mqtt-zway-plugin",
 	"icon": "icon.png",
 	"maturity": "stable",
-	"moduleName": "WBMQTT150",
+	"moduleName": "WBMQTT",
 	"singleton": false,
 	"version": "1.5.0",
 	"repository": {

--- a/module.json
+++ b/module.json
@@ -21,7 +21,7 @@
 	"homepage": "https://github.com/wirenboard/wb-mqtt-zway-plugin",
 	"icon": "icon.png",
 	"maturity": "stable",
-	"moduleName": "WBMQTT",
+	"moduleName": "WBMQTT150",
 	"singleton": false,
 	"version": "1.5.0",
 	"repository": {


### PR DESCRIPTION
Для старых релизов решили создать отдельное приложение в магазине, чтобы работало на старой сборке сервера. 
Привести конкретную ссылку на новый плагин в тексте не могу, так как ссылка на приложение формируется не по его названию а по номеру, как этот номер будет меняться в будущем не известно, есть вероятность что ссылка протухнет как только мы выкатим новый релиз и номер в ссылке вдруг изменится
UPD решили оставить под старым именем предыдущу версию плагина, чтобы у пользователей ничего не сломалось, если они захотят обновиться из магазина. Переименуем новую версию плагина. Изменила только описание